### PR TITLE
Potential fix for code scanning alert no. 1: Bad HTML filtering regexp

### DIFF
--- a/app/api/contact/route.ts
+++ b/app/api/contact/route.ts
@@ -1,4 +1,5 @@
 import { type NextRequest, NextResponse } from "next/server"
+import sanitizeHtml from "sanitize-html";
 
 // Rate limiting store (in production, use Redis or database)
 const rateLimitStore = new Map<string, { count: number; resetTime: number }>()
@@ -52,10 +53,7 @@ function isRateLimited(ip: string): boolean {
 }
 
 function sanitizeInput(input: string): string {
-  return input
-    .replace(/<script\b[^<]*(?:(?!<\/script>)<[^<]*)*<\/script>/gi, "")
-    .replace(/<[^>]*>/g, "")
-    .trim()
+  return sanitizeHtml(input, { allowedTags: [], allowedAttributes: {} }).trim();
 }
 
 function detectSpam(data: any): boolean {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
     "tailwind-merge": "^2.5.5",
     "tailwindcss-animate": "^1.0.7",
     "vaul": "latest",
-    "zod": "^3.24.1"
+    "zod": "^3.24.1",
+    "sanitize-html": "^2.17.0"
   },
   "devDependencies": {
     "@types/node": "^22",


### PR DESCRIPTION
Potential fix for [https://github.com/DebaA17/PORTFOLIO/security/code-scanning/1](https://github.com/DebaA17/PORTFOLIO/security/code-scanning/1)

To robustly sanitize user input and remove possible script or other malicious HTML without risking bypass by tricky tag variants, the best fix is to replace this custom regular expression-based solution with a well-maintained HTML sanitization library. On the server side in a Next.js/Node.js application, a commonly used library for this purpose is `sanitize-html`. This library properly handles edge cases in HTML parsing and tag closing, and is kept up to date for security best practices.

To implement this:
- Import `sanitize-html` at the top of `app/api/contact/route.ts`.
- Change the `sanitizeInput` function to use `sanitizeHtml(input, { allowedTags: [] })`.  
  The `{ allowedTags: [] }` option strips ALL tags, which is equivalent to wanting plain text output.
- Remove all use of custom regexes in `sanitizeInput`.
- Optionally, ensure that `sanitize-html` is present in your `package.json` (`npm install sanitize-html`).

Only `app/api/contact/route.ts` needs to be edited, at the import region and the body of the `sanitizeInput` function (lines 54–59).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
